### PR TITLE
Improve error message in `issue_asset.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ poetry run wallet-helper --assets
 
 Issue at least one asset. If no allocation slots are available, some will be
 created automatically. As an example:
+
+> Note: issuance in RGB may require the wallet to create new UTXOs,
+> It means it must somehow deal with the blockchain.
+> The default configuration is for testnet. Thus to run the following command
+> for other networks requires you to specify `ELECTRUM_URL` in `config.py`.
+
+
 ```shell
 poetry run issue-asset rgb20 "fungible token" 0 1000 1000 --ticker "FFA"
 poetry run issue-asset rgb121 "CTB" 0 10 10 --description "a collectible" --file_path ./README.md

--- a/issue_asset.py
+++ b/issue_asset.py
@@ -83,4 +83,8 @@ def entrypoint():
         print(f'{count} new UTXOs created')
     except rgb_lib.RgbLibError.AllocationsAlreadyAvailable:
         pass
+    except rgb_lib.RgbLibError.InsufficientBitcoins as err:
+        print((f'Insufficient funds ({err.available} available sats).\n'
+               f'Funds can be sent to the following address'), wallet.get_address())
+        sys.exit(1)
     _issue_asset(wallet, online, args)


### PR DESCRIPTION
In case of insufficient funds error, It is not clear which address that an user must send dummy funds.
Thus show it before quitting the program.

Also add minor note on README that `ELECTRUM_URL` must be specified before issuing assets.